### PR TITLE
Eliminate Off-By-One Error When Calculating Work Days In A Month

### DIFF
--- a/hours-stat.rb
+++ b/hours-stat.rb
@@ -163,7 +163,7 @@ hour_storage.hours_by_year_month_code.sort_by { |k,v| k }.each do |year, hours_b
 
     first_day_of_month = Date.new(year, month, 1)
     last_day_of_month = Date.new(year, month, 1).next_month.prev_day
-    kuussa_tunteja_yhteensä = 7.5 * (1 + business_days_between(first_day_of_month,
+    kuussa_tunteja_yhteensä = 7.5 * (business_days_between(first_day_of_month,
                                                                [last_day_of_month, Date.today].min) -
                                      holiday_counter.for_month(year, month))
 

--- a/hours-stat.rb
+++ b/hours-stat.rb
@@ -101,6 +101,10 @@ def perce(f)
   "#{(f * 100).round(1)}"
 end
 
+def div(dividend, divisor)
+  return divisor == 0 ? 0 : dividend / divisor
+end
+
 class HourStorage
   attr_reader :hours_by_year_month_code
 
@@ -170,17 +174,17 @@ hour_storage.hours_by_year_month_code.sort_by { |k,v| k }.each do |year, hours_b
     puts "\n  ### #{months[month-1]} #{year}"
 
     puts "  Yhteensä #{tehdyt_tunnit_yhteensä} h kuukauden #{kuussa_tunteja_yhteensä} työtunnista joista"
-    puts "    - laskutettavia #{laskutettavat_yhteensä} h, laskutusaste #{perce(laskutettavat_yhteensä / kuussa_tunteja_yhteensä)} %"
+    puts "    - laskutettavia #{laskutettavat_yhteensä} h, laskutusaste #{perce(div(laskutettavat_yhteensä, kuussa_tunteja_yhteensä))} %"
     laskutettavat.nonzero_values_descending.each do |tuntikoodi, tunnit|
       puts "       #{tunnit}\t#{tuntikoodi}"
     end
 
-     puts "    - laskutettamattomia #{muut_yhteensä} h, laskuttamattomuusaste #{perce(muut_yhteensä / kuussa_tunteja_yhteensä)} %"
+     puts "    - laskutettamattomia #{muut_yhteensä} h, laskuttamattomuusaste #{perce(div(muut_yhteensä, kuussa_tunteja_yhteensä))} %"
      muut.nonzero_values_descending.each do |tuntikoodi, tunnit|
        puts "       #{tunnit}\t#{tuntikoodi}"
     end
   end
 
-  puts "\nVuonna #{year} yhteensä:\n#{koko_vuoden_tehdyt} h vuoden #{vuodessa_tunteja} työtunnista joista laskutettavia #{koko_vuoden_laskutettavat} h, laskutusaste #{perce(koko_vuoden_laskutettavat / vuodessa_tunteja)} %\n"
+  puts "\nVuonna #{year} yhteensä:\n#{koko_vuoden_tehdyt} h vuoden #{vuodessa_tunteja} työtunnista joista laskutettavia #{koko_vuoden_laskutettavat} h, laskutusaste #{perce(div(koko_vuoden_laskutettavat, vuodessa_tunteja))} %\n"
 end
 


### PR DESCRIPTION
hours-stat.rb made an off-by-one error to all figures representing work days in a month. Invalid billing percentages were produced (one days worth less than they really were).

My theory is that the extra `+ 1` existed to avoid the division of zero case that would produce a `NaN`. Replaced this with a "zero-safe" division function.

The output seems to produce correct total work hours in a month figures now.