### PR TITLE
Fixed a couple of bugs

### DIFF
--- a/hours-stat.rb
+++ b/hours-stat.rb
@@ -19,7 +19,8 @@ class HolidayCount
     File.open("#{$hours_dir}/holidays.txt") do |f|
       while (line = f.gets) do
         d = Date.strptime(line.split(' ')[0], "%d.%m.%Y")
-        if not d.saturday? and not d.sunday?
+        # Don't count holidays that are either in the weekends or in the future
+        if not d.saturday? and not d.sunday? and not d > Date.today
           @holidays_per_month[key_for_date(d)] += 1
         end
       end
@@ -164,15 +165,22 @@ hour_storage.hours_by_year_month_code.sort_by { |k,v| k }.each do |year, hours_b
 
     first_day_of_month = Date.new(year, month, 1)
     last_day_of_month = Date.new(year, month, 1).next_month.prev_day
-    kuussa_tunteja_yhteensä = 7.5 * (business_days_between(first_day_of_month,
-                                                               [last_day_of_month, Date.today].min) -
-                                     holiday_counter.for_month(year, month))
+
+    # If counting business days of current month include today by counting from tomorrow; hence the + 1
+    business_days = business_days_between(first_day_of_month, [last_day_of_month, Date.today + 1].min)
+    holidays = holiday_counter.for_month(year, month)
+    workdays = business_days - holidays
+    # TIL you can't just substract holidays from business days and get workdays. You have to + 1 in order to get the correct result. I am too tired right now to understand why. If you get it please pm @horttanainen.
+    workdays = if holidays.zero? then business_days else business_days - holidays + 1 end
+
+    kuussa_tunteja_yhteensä = 7.5 * workdays;
 
     koko_vuoden_laskutettavat += laskutettavat_yhteensä
     koko_vuoden_tehdyt += tehdyt_tunnit_yhteensä
     vuodessa_tunteja += kuussa_tunteja_yhteensä
 
-    puts "\n  ### #{months[month-1]} #{year}"
+    # Added a breakdown of days used in the calculations to help in bug spotting (and to fuck with people's minds -- why the fuck business_days - holidays != workdays???)
+    puts "\n  ### #{months[month-1]} #{year} (#{business_days} arkipäivää, #{holidays} arkipäiviin osuvaa vapaapäivää ja #{workdays} työpäivää)"
 
     puts "  Yhteensä #{tehdyt_tunnit_yhteensä} h kuukauden #{kuussa_tunteja_yhteensä} työtunnista joista"
     puts "    - laskutettavia #{laskutettavat_yhteensä} h, laskutusaste #{perce(div(laskutettavat_yhteensä, kuussa_tunteja_yhteensä))} %"


### PR DESCRIPTION
This PR fixes the following behaviour:

At the time of writing this:
In May there are 
22 business days 
2 holidays
21 workdays

but the script returned the following:
22 business days
2 holidays
20 workdays

Again in June there are
14 business days
0 holidays
14 workdays

but the script returned the following:
13 business days
1 holidays
12 workdays

I have been working at Reaktor only a couple of months now, so my data is a bit limited. Somebody please check my fixes against other months with holidays.
