### PR TITLE
Encoding and data formatting fixes

### DIFF
--- a/hours-stat.rb
+++ b/hours-stat.rb
@@ -5,6 +5,8 @@ require 'date'
 require 'json'
 require 'optparse'
 
+Encoding.default_external = Encoding::UTF_8
+
 $options = {}
 OptionParser.new do |opt|
   opt.on('--lang LANG', [:fi, :en], "Language (fi/en)") { |l| $options[:lang] = l }
@@ -33,16 +35,16 @@ $strings = { :unknown_project => {
                :en => "  Total of %{done_hours} h out of %{hours_in_month} of the month, out of which"
              },
              :billable => {
-               :fi => "    - laskutettavia %{hours} h, laskutusaste %{ratio} %",
-               :en => "    - billable %{hours} h, billing ratio %{ratio} %"
+               :fi => "    - laskutettavia %{hours} h, laskutusaste %{ratio} %%",
+               :en => "    - billable %{hours} h, billing ratio %{ratio} %%"
              },
              :hours_per_code => {
                :fi => "       %{hours}\t%{code}",
                :en => "       %{hours}\t%{code}"
              },
              :non_billable => {
-               :fi => "    - laskutettamattomia %{hours} h, laskuttamattomuusaste %{ratio} %",
-               :en => "    - non-billable %{hours} h, non-billing ratio %{ratio} %"
+               :fi => "    - laskutettamattomia %{hours} h, laskuttamattomuusaste %{ratio} %%",
+               :en => "    - non-billable %{hours} h, non-billing ratio %{ratio} %%"
              },
              :year_total => {
                :fi => "\nVuonna %{year} yhteensä (olettaen %{hours_per_day} h työpäivän):\n%{done_hours} h vuoden %{hours_in_year} työtunnista joista laskutettavia %{billable_in_year} h, laskutusaste %{billing_ratio} %\n",


### PR DESCRIPTION
Testing on Ruby 2.5.1 on Mac OS Mojave

On first round:
````
l932:~ $ ruby hours-stat.rb
Traceback (most recent call last):
	5: from hours-stat.rb:189:in `<main>'
	4: from hours-stat.rb:189:in `new'
	3: from hours-stat.rb:68:in `initialize'
	2: from hours-stat.rb:68:in `open'
	1: from hours-stat.rb:70:in `block in initialize'
hours-stat.rb:70:in `split': invalid byte sequence in US-ASCII (ArgumentError)
l932:~ $
````

After fixing this with `Encoding...`
````
l932:~ $ ruby hours-stat.rb
#### Vuosi 2016 #####

  ### Elokuu 2016 (23 arkipäivää, 0 arkipäiviin osuvaa vapaapäivää ja 23 työpäivää)
  Yhteensä XX.XX h kuukauden XXX.X työtunnista joista
Traceback (most recent call last):
	5: from hours-stat.rb:219:in `<main>'
	4: from hours-stat.rb:219:in `each'
	3: from hours-stat.rb:226:in `block in <main>'
	2: from hours-stat.rb:226:in `each'
	1: from hours-stat.rb:253:in `block (2 levels) in <main>'
hours-stat.rb:253:in `%': incomplete format specifier; use %% (double %) instead (ArgumentError)
````

After fixes to format strings, it started to work beatifully.